### PR TITLE
Attribute-based Page Registration

### DIFF
--- a/src/Tkmm/App.axaml.cs
+++ b/src/Tkmm/App.axaml.cs
@@ -127,18 +127,16 @@ public partial class App : Application
                         "fa-solid fa-triangle-exclamation", isWorkingStatus: false);
                 }
             }
-
-            PageManager.Shared.Register(Page.Home, "Home", new HomePageView(), Symbol.Home, "Home", isDefault: true);
-            PageManager.Shared.Register(Page.Profiles, "Profiles", new ProfilesPageView(), Symbol.OtherUser, "Manage mod profiles");
-            PageManager.Shared.Register(Page.Tools, "TKCL Packager", new PackagingPageView(), Symbol.CodeHTML, "Mod developer tools");
-            PageManager.Shared.Register(Page.ShopParam, "ShopParam Overflow Editor", new ShopParamPageView(), Symbol.Sort, "ShopParam overflow ordering tools");
-
-            if (GameBananaHelper.IsOnline) {
-                PageManager.Shared.Register(Page.Mods, "GameBanana Mod Browser", new GameBananaPageView(), Symbol.Globe, "GameBanana browser client for TotK mods");
-            }
             
-            PageManager.Shared.Register(Page.Logs, "Logs", new LogsPageView(), Symbol.AllApps, "System Logs", isFooter: true);
-            PageManager.Shared.Register(Page.Settings, "Settings", settingsPage, Symbol.Settings, "Settings", isFooter: true, isDefault: isValid == false);
+            PageManager.Init(
+                afterNormals: pm => {
+                    if (GameBananaHelper.IsOnline) {
+                        pm.Register(Page.Mods, "GameBanana Mod Browser", new GameBananaPageView(), Symbol.Globe, "GameBanana browser client for TotK mods");
+                    }
+                }, 
+                afterFooters: pm =>
+                    pm.Register(Page.Settings, nameof(Page.Settings), settingsPage, Symbol.Settings, nameof(Page.Settings), isFooter: true, isDefault: isValid == false)
+                );
 
             Config.SetTheme(Config.Shared.Theme);
         }
@@ -148,7 +146,7 @@ public partial class App : Application
 
     public static void Focus()
     {
-        if (Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop && desktop.MainWindow is not null) {
+        if (Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime { MainWindow: not null } desktop) {
             desktop.MainWindow.WindowState = WindowState.Normal;
             desktop.MainWindow.Activate();
         }

--- a/src/Tkmm/Attributes/PageAttribute.cs
+++ b/src/Tkmm/Attributes/PageAttribute.cs
@@ -1,0 +1,29 @@
+﻿using FluentAvalonia.UI.Controls;
+using Tkmm.Helpers;
+
+namespace Tkmm.Attributes;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class PageAttribute : Attribute
+{
+    public PageAttribute(Page page, string description, Symbol icon, string? title = null,
+        bool isDefault = false, bool isFooter = false)
+    {
+        Page = page;
+        Title = title ?? Enum.GetName(page)!;
+        Description = description;
+        Icon = icon;
+        IsDefault = isDefault;
+        IsFooter = isFooter;
+    }
+
+    public string Title { get; init; }
+    public string Description { get; init; }
+    public Page Page { get; init; }
+    public Symbol Icon { get; init; }
+    public bool IsDefault { get; init; }
+    public bool IsFooter { get; init; }
+}
+
+[AttributeUsage(AttributeTargets.Class)]
+public class DontAutoRegisterAttribute : Attribute;

--- a/src/Tkmm/Views/Pages/GameBananaPageView.axaml.cs
+++ b/src/Tkmm/Views/Pages/GameBananaPageView.axaml.cs
@@ -1,8 +1,12 @@
 using Avalonia.Controls;
 using Avalonia.Input;
+using FluentAvalonia.UI.Controls;
+using Tkmm.Attributes;
+using Tkmm.Helpers;
 using Tkmm.ViewModels.Pages;
 
 namespace Tkmm.Views.Pages;
+
 public partial class GameBananaPageView : UserControl
 {
     public GameBananaPageView()

--- a/src/Tkmm/Views/Pages/HomePageView.axaml.cs
+++ b/src/Tkmm/Views/Pages/HomePageView.axaml.cs
@@ -1,9 +1,13 @@
 using Avalonia;
 using Avalonia.Controls;
+using FluentAvalonia.UI.Controls;
+using Tkmm.Attributes;
+using Tkmm.Helpers;
 using Tkmm.ViewModels.Pages;
 
 namespace Tkmm.Views.Pages;
 
+[Page(Page.Home, nameof(Page.Home), Symbol.Home, isDefault: true)]
 public partial class HomePageView : UserControl
 {
     public HomePageView()

--- a/src/Tkmm/Views/Pages/LogsPageView.axaml.cs
+++ b/src/Tkmm/Views/Pages/LogsPageView.axaml.cs
@@ -1,7 +1,12 @@
 using Avalonia.Controls;
+using FluentAvalonia.UI.Controls;
+using Tkmm.Attributes;
+using Tkmm.Helpers;
 using Tkmm.ViewModels.Pages;
 
 namespace Tkmm.Views.Pages;
+
+[Page(Page.Logs, "System Logs", Symbol.AllApps, isFooter: true)]
 public partial class LogsPageView : UserControl
 {
     public LogsPageView()

--- a/src/Tkmm/Views/Pages/PackagingPageView.axaml.cs
+++ b/src/Tkmm/Views/Pages/PackagingPageView.axaml.cs
@@ -1,8 +1,12 @@
 using Avalonia.Controls;
+using FluentAvalonia.UI.Controls;
+using Tkmm.Attributes;
+using Tkmm.Helpers;
 using Tkmm.ViewModels.Pages;
 
 namespace Tkmm.Views.Pages;
 
+[Page(Page.Tools, "Mod developer tools", Symbol.CodeHTML, "TKCL Packager")]
 public partial class PackagingPageView : UserControl
 {
     public PackagingPageView()

--- a/src/Tkmm/Views/Pages/ProfilesPageView.axaml.cs
+++ b/src/Tkmm/Views/Pages/ProfilesPageView.axaml.cs
@@ -2,9 +2,13 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
+using FluentAvalonia.UI.Controls;
+using Tkmm.Attributes;
+using Tkmm.Helpers;
 
 namespace Tkmm.Views.Pages;
 
+[Page(Page.Profiles, "Manage mod profiles", Symbol.OtherUser)]
 public partial class ProfilesPageView : UserControl
 {
     public ProfilesPageView()

--- a/src/Tkmm/Views/Pages/ShopParamPageView.axaml.cs
+++ b/src/Tkmm/Views/Pages/ShopParamPageView.axaml.cs
@@ -1,8 +1,12 @@
 using Avalonia.Controls;
+using FluentAvalonia.UI.Controls;
+using Tkmm.Attributes;
+using Tkmm.Helpers;
 using Tkmm.ViewModels.Pages;
 
 namespace Tkmm.Views.Pages;
 
+[Page(Page.ShopParam, "ShopParam overflow ordering tools", Symbol.Sort, "ShopParam Overflow Editor")]
 public partial class ShopParamPageView : UserControl
 {
     public ShopParamPageView()


### PR DESCRIPTION
Instead of manually calling `PageManager.Shared.Register(...)` for each page, simply add an attribute with the relevant information and it will be added exactly where in the code it was before.

The method called on startup also exposes 4 callbacks: for before & after, both normal & footer page entries; so you can add pages (basically) anywhere inside the auto-registration flow.