### PR TITLE
Improve GameBananaHelper.IsOnline

### DIFF
--- a/src/Tkmm.Core/Helpers/GameBananaHelper.cs
+++ b/src/Tkmm.Core/Helpers/GameBananaHelper.cs
@@ -8,7 +8,7 @@ public static class GameBananaHelper
     {
         try {
             return new Ping()
-                .Send("gamebanana.com", 10000).Status == IPStatus.Success;
+                .Send("gamebanana.com", 10_000).Status is IPStatus.Success;
         } catch {
             return false;
         }

--- a/src/Tkmm.Core/Helpers/GameBananaHelper.cs
+++ b/src/Tkmm.Core/Helpers/GameBananaHelper.cs
@@ -4,7 +4,8 @@ namespace Tkmm.Core.Helpers;
 
 public static class GameBananaHelper
 {
-    public static bool IsOnline() {
+    public static bool IsOnline()
+    {
         try {
             return new Ping()
                 .Send("gamebanana.com", 10000).Status == IPStatus.Success;

--- a/src/Tkmm.Core/Helpers/GameBananaHelper.cs
+++ b/src/Tkmm.Core/Helpers/GameBananaHelper.cs
@@ -9,7 +9,8 @@ public static class GameBananaHelper
         try {
             return new Ping()
                 .Send("gamebanana.com", 10_000).Status is IPStatus.Success;
-        } catch {
+        }
+        catch {
             return false;
         }
     }

--- a/src/Tkmm.Core/Helpers/GameBananaHelper.cs
+++ b/src/Tkmm.Core/Helpers/GameBananaHelper.cs
@@ -4,16 +4,14 @@ namespace Tkmm.Core.Helpers;
 
 public static class GameBananaHelper
 {
-    private static readonly Lazy<bool> _isOnline = new(() =>
-        {
-            try {
-                return new Ping()
-                    .Send("gamebanana.com", 10000).Status == IPStatus.Success;
-            }
-            catch {
-                return false;
-            }
-        });
+    private static readonly Lazy<bool> _isOnline = new(() => {
+        try {
+            return new Ping()
+                .Send("gamebanana.com", 10000).Status == IPStatus.Success;
+        } catch {
+            return false;
+        }
+    });
 
 
     public static bool IsOnline => _isOnline.Value;

--- a/src/Tkmm.Core/Helpers/GameBananaHelper.cs
+++ b/src/Tkmm.Core/Helpers/GameBananaHelper.cs
@@ -4,17 +4,19 @@ namespace Tkmm.Core.Helpers;
 
 public static class GameBananaHelper
 {
-    public static bool IsOnline {
-        get {
+    private static readonly Lazy<bool> _isOnline = new(() =>
+        {
             try {
                 return new Ping()
-                    .Send("www.google.com", 1000).Status == IPStatus.Success;
+                    .Send("gamebanana.com", 10000).Status == IPStatus.Success;
             }
             catch {
                 return false;
             }
-        }
-    }
+        });
+
+
+    public static bool IsOnline => _isOnline.Value;
 
     private const string BASE_URL = "https://gamebanana.com/apiv11";
     private static readonly HttpClient _client = new();

--- a/src/Tkmm.Core/Helpers/GameBananaHelper.cs
+++ b/src/Tkmm.Core/Helpers/GameBananaHelper.cs
@@ -4,17 +4,14 @@ namespace Tkmm.Core.Helpers;
 
 public static class GameBananaHelper
 {
-    private static readonly Lazy<bool> _isOnline = new(() => {
+    public static bool IsOnline() {
         try {
             return new Ping()
                 .Send("gamebanana.com", 10000).Status == IPStatus.Success;
         } catch {
             return false;
         }
-    });
-
-
-    public static bool IsOnline => _isOnline.Value;
+    }
 
     private const string BASE_URL = "https://gamebanana.com/apiv11";
     private static readonly HttpClient _client = new();

--- a/src/Tkmm/App.axaml.cs
+++ b/src/Tkmm/App.axaml.cs
@@ -135,7 +135,7 @@ public partial class App : Application
             PageManager.Shared.Register(Page.Tools, "TKCL Packager", new PackagingPageView(), Symbol.CodeHTML, "Mod developer tools");
             PageManager.Shared.Register(Page.ShopParam, "ShopParam Overflow Editor", new ShopParamPageView(), Symbol.Sort, "ShopParam overflow ordering tools");
 
-            if (GameBananaHelper.IsOnline) {
+            if (GameBananaHelper.IsOnline()) {
                 PageManager.Shared.Register(Page.Mods, "GameBanana Mod Browser", new GameBananaPageView(), Symbol.Globe, "GameBanana browser client for TotK mods");
             }
             


### PR DESCRIPTION
[About 45 minutes ago](https://discord.com/channels/1179611100183011429/1191595001088573450/1278900440422944789) from me making this PR, a user from China using a VPN with TKMM asked for help in the Discord server because they were unable to use the GameBanana browser built into TKMM.
[This change fixed their issue!](https://discord.com/channels/1179611100183011429/1191595001088573450/1278908545412104202)

I noticed the [`Ping`](https://learn.microsoft.com/en-us/dotnet/api/system.net.networkinformation.ping?view=net-8.0) object's Send method [had a timeout of one second](https://discord.com/channels/1179611100183011429/1191595001088573450/1278905182255714314).
After some thought it occurred to me that VPNs are notoriously slow. Even my own experience using a VPN from not the other side of the world, and I could tell that one second was far too short.

On top of that, I also ping GameBanana instead of google because Google can very easily be blocked in someone's country but GameBanana might not be. Same idea there as #48.

The timeout is up for change, however I figure 10 seconds is a good enough timeout for bad internet + VPN. If your internet is good enough this change effects nothing.

