### PR TITLE
dotnet self contained

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,8 @@ jobs:
           -p:DebugType=embedded \
           -p:IncludeNativeLibrariesForSelfExtract=true \
           -p:PublishSingleFile=true \
-          -p:Version=${{ needs.release.outputs.version }}
+          -p:Version=${{ needs.release.outputs.version }} \
+          --self-contained
 
       - name: Rename Executable
         shell: bash


### PR DESCRIPTION
self contained allows the runtime to be bundled with the program making it possible to run without dotnet installed