### PR TITLE
Move to top/bottom buttons now remove & insert, instead of swap items.

### DIFF
--- a/src/Tkmm/ViewModels/Pages/HomePageViewModel.cs
+++ b/src/Tkmm/ViewModels/Pages/HomePageViewModel.cs
@@ -1,4 +1,4 @@
-﻿#if RELEASE
+#if RELEASE
 using Avalonia.Threading;
 #endif
 using Avalonia.Controls;
@@ -70,13 +70,34 @@ public partial class HomePageViewModel : ObservableObject
     [RelayCommand]
     private static void MoveToTop()
     {
-        TKMM.ModManager.GetCurrentProfile().MoveToTop();
+        var profile = TKMM.ModManager.GetCurrentProfile();
+        var target = profile.Selected;
+        if (target is null) return;
+
+        var mods = profile.Mods;
+        int currentIndex = mods.IndexOf(target);
+        if (currentIndex <= 0) return;
+
+        mods.RemoveAt(currentIndex);
+        mods.Insert(0, target);
+        profile.Selected = target;
     }
 
     [RelayCommand]
     private static void MoveToBottom()
     {
-        TKMM.ModManager.GetCurrentProfile().MoveToBottom();
+        var profile = TKMM.ModManager.GetCurrentProfile();
+        var target = profile.Selected;
+        if (target is null) return;
+
+        var mods = profile.Mods;
+        int currentIndex = mods.IndexOf(target);
+        int lastIndex = mods.Count - 1;
+        if (currentIndex < 0 || currentIndex >= lastIndex) return;
+
+        mods.RemoveAt(currentIndex);
+        mods.Add(target);
+        profile.Selected = target;
     }
 
     [RelayCommand]

--- a/src/Tkmm/Views/Pages/HomePageView.axaml
+++ b/src/Tkmm/Views/Pages/HomePageView.axaml
@@ -296,7 +296,7 @@
                     Background="{DynamicResource SystemAccentColor}" />
 
             <Grid Name="ModListGrid" Grid.Column="2">
-                <ListBox Classes="ModDragDropListBox"
+                <ListBox Name="ModsList"
                          DragDrop.AllowDrop="True"
                          ItemsSource="{Binding ModManager.CurrentProfile.Mods}"
                          SelectedItem="{Binding ModManager.CurrentProfile.Selected}"

--- a/src/Tkmm/Views/Pages/HomePageView.axaml.cs
+++ b/src/Tkmm/Views/Pages/HomePageView.axaml.cs
@@ -18,6 +18,15 @@ public partial class HomePageView : UserControl
         InitializeComponent();
 
         base.OnAttachedToVisualTree(e);
+
+        var listBox = this.FindControl<ListBox>("ModsList");
+        if (listBox is not null) {
+            listBox.PropertyChanged += (_, args) => {
+                if (args.Property.Name == nameof(ListBox.SelectedItem) && listBox.SelectedItem is not null) {
+                    listBox.ScrollIntoView(listBox.SelectedItem);
+                }
+            };
+        }
     }
 
     private void GridSplitter_DragCompleted(object? sender, Avalonia.Input.VectorEventArgs e)


### PR DESCRIPTION
Hi Tkmm team. I'm not a programmer, but I noticed this small bug and as a learning exercise I worked with Cursor AI to prep this PR.
I did test that its changes produce the desired results on my machine.
If you have any feedback about the execution I can learn for next time (or lessons on github decorum) I would be glad to hear them and adjust in future.


- Updates “Move to Top/Bottom” to move the selected mod to the top/bottom via remove/insert, preserving other mods’ relative order. Previously, these buttons _swapped_ the selected mod with the bottom/topmost one.
- Keeps the moved mod selected, so the preview pane stays focused on it, and scrolls the list to the selected mod is visible.

Details
- HomePageViewModel.cs: After reordering, explicitly reassign profile.Selected = target to preserve selection.
- HomePageView.axaml/.cs: Name the list (ModsList) and call ScrollIntoView when SelectedItem changes.
- No changes to build/CI or submodules; UI/UX only.